### PR TITLE
conv/resadd stride  and operand reuse

### DIFF
--- a/bareMetalC/Makefile
+++ b/bareMetalC/Makefile
@@ -50,6 +50,7 @@ tests = \
 	transpose \
 	matrix_add \
 	resadd \
+	resadd_stride \
 	global_average \
 	gemmini_counter \
 	template \

--- a/bareMetalC/Makefile
+++ b/bareMetalC/Makefile
@@ -18,6 +18,7 @@ tests = \
 	padded \
 	mvin_scale \
 	conv \
+	conv_stride \
 	conv_rect \
 	conv_with_pool \
 	conv_with_rot180 \

--- a/bareMetalC/conv_stride.c
+++ b/bareMetalC/conv_stride.c
@@ -23,9 +23,9 @@
 
 #define IN_ROW_DIM 14
 #define IN_COL_DIM 14
-#define IN_CHANNELS 18
-#define OUT_CHANNELS 19
-#define BATCH_SIZE 1
+#define IN_CHANNELS 16
+#define OUT_CHANNELS 18
+#define BATCH_SIZE 2
 #define KERNEL_DIM 3
 #define PADDING 1
 #define STRIDE 2
@@ -39,9 +39,9 @@
 #define PATCH_SIZE (KERNEL_DIM * KERNEL_DIM * IN_CHANNELS)
 #define N_PATCHES (BATCH_SIZE * OUT_ROW_DIM * OUT_COL_DIM)
 
-#define IN_STRIDE (IN_CHANNELS + 4)
-#define WEIGHT_STRIDE (OUT_CHANNELS + 13)
-#define OUT_STRIDE (OUT_CHANNELS + 5)
+#define IN_STRIDE (IN_CHANNELS + 6)
+#define WEIGHT_STRIDE (OUT_CHANNELS + 14)
+#define OUT_STRIDE (OUT_CHANNELS + 2)
 
 void conv(int batch_size, int in_channels,
         int in_row_dim, int in_col_dim,
@@ -211,7 +211,7 @@ int main() {
 
     printf("Gemmini conv...\n");
     uint64_t start_gemmini = read_cycles();
-    tiled_conv_full(
+    tiled_conv_stride_auto(
         BATCH_SIZE, IN_ROW_DIM, IN_COL_DIM, IN_CHANNELS,
         OUT_CHANNELS, OUT_ROW_DIM, OUT_COL_DIM,
         STRIDE, 1, 1, PADDING, KERNEL_DIM,

--- a/bareMetalC/conv_stride.c
+++ b/bareMetalC/conv_stride.c
@@ -1,0 +1,322 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#ifndef BAREMETAL
+#include <sys/mman.h>
+#endif
+#include "include/gemmini_testutils.h"
+
+#ifndef BAREMETAL
+
+#define BATCH_SIZE 4
+#define IN_ROW_DIM 224
+#define IN_COL_DIM 224
+#define IN_CHANNELS 3
+#define OUT_CHANNELS 32
+#define KERNEL_DIM 3
+#define PADDING 1
+#define STRIDE 2
+
+#else
+
+#define IN_ROW_DIM 14
+#define IN_COL_DIM 14
+#define IN_CHANNELS 18
+#define OUT_CHANNELS 19
+#define BATCH_SIZE 1
+#define KERNEL_DIM 3
+#define PADDING 1
+#define STRIDE 2
+
+#endif
+
+#define NO_BIAS false
+
+#define OUT_ROW_DIM ((IN_ROW_DIM + 2*PADDING - KERNEL_DIM) / STRIDE + 1)
+#define OUT_COL_DIM ((IN_COL_DIM + 2*PADDING - KERNEL_DIM) / STRIDE + 1)
+#define PATCH_SIZE (KERNEL_DIM * KERNEL_DIM * IN_CHANNELS)
+#define N_PATCHES (BATCH_SIZE * OUT_ROW_DIM * OUT_COL_DIM)
+
+#define IN_STRIDE (IN_CHANNELS + 4)
+#define WEIGHT_STRIDE (OUT_CHANNELS + 13)
+#define OUT_STRIDE (OUT_CHANNELS + 5)
+
+void conv(int batch_size, int in_channels,
+        int in_row_dim, int in_col_dim,
+        int out_channels, int kernel_dim,
+        int out_row_dim, int out_col_dim,
+        int stride, int padding,
+        int in_stride, int out_stride,
+        elem_t input[batch_size][in_row_dim][in_col_dim][in_stride],
+        elem_t weights[out_channels][kernel_dim][kernel_dim][in_channels],
+        acc_t bias[out_channels],
+        elem_t output[batch_size][out_row_dim][out_col_dim][out_stride]) {
+
+#ifdef GEMMINI_ASSERTIONS
+    if (out_row_dim != (in_row_dim + 2 * padding - kernel_dim) / stride + 1) {
+        printf("conv out_row_dim is not correct\n");
+        exit(1);
+    }
+
+    if (out_col_dim != (in_col_dim + 2 * padding - kernel_dim) / stride + 1) {
+        printf("conv out_col_dim is not correct\n");
+        exit(1);
+    }
+#endif
+
+    for (int b = 0; b < batch_size; b++) {
+        for (int orow = 0; orow < out_row_dim; orow++) {
+            for (int ocol = 0; ocol < out_col_dim; ocol++) {
+                for (int och = 0; och < out_channels; och++) {
+                    acc_t result = bias[och];
+
+                    for (int krow = 0; krow < kernel_dim; krow++) {
+                        for (int kcol = 0; kcol < kernel_dim; kcol++) {
+                            for (int kch = 0; kch < in_channels; kch++) {
+                                int irow = orow * stride + krow - padding;
+                                int icol = ocol * stride + kcol - padding;
+
+                                elem_t pixel = irow < 0 || irow >= in_row_dim ||
+                                    icol < 0 || icol >= in_col_dim ?
+                                    0 : input[b][irow][icol][kch];
+
+                                result +=
+                                    weights[och][krow][kcol][kch] *
+                                    pixel;
+                            }
+                        }
+                    }
+
+                    // Clip result
+                    result = result > elem_t_max ? elem_t_max : (result < elem_t_min ? elem_t_min : result);
+
+                    output[b][orow][ocol][och] = result;
+                }
+            }
+        }
+    }
+}
+
+void flatten_weights(int out_channels, int kernel_dim, int in_channels,
+        int patch_size, int out_stride,
+        elem_t weights[out_channels][kernel_dim][kernel_dim][in_channels],
+        elem_t weights_mat[patch_size][out_stride]) {
+
+    assert(patch_size == kernel_dim * kernel_dim * in_channels);
+
+    for (int outc = 0; outc < out_channels; outc++) {
+        for (int krow = 0; krow < kernel_dim; krow++) {
+            for (int kcol = 0; kcol < kernel_dim; kcol++) {
+                for (int inc = 0; inc < in_channels; inc++) {
+                    int wmatrow = krow * kernel_dim * in_channels +
+                        kcol * in_channels +
+                        inc;
+
+                    weights_mat[wmatrow][outc] =
+                        weights[outc][krow][kcol][inc];
+                }
+            }
+        }
+    }
+}
+
+bool vec_is_equal(elem_t * a, elem_t * b, int len) {
+    for (int i = 0; i < len; i++)
+        if (a[i] != b[i])
+            return false;
+    return true;
+}
+
+void init_random(elem_t * buf, int row, int col, int stride){
+    elem_t i = 0;
+    for(int r = 0; r < row; r++){
+        for(int c = 0; c < col; c++){
+            elem_t * ptr = buf + row * stride + col;
+            *ptr = (rand() % 5) - 2;
+        }
+    }
+}
+
+void init_random_acc(acc_t * buf, int len) {
+    elem_t i = 0;
+    for (acc_t * ptr = buf; ptr < buf + len; ptr++) {
+        // *ptr = (rand() % 32) - 16;
+      *ptr = (rand() % 5) - 2;
+    }
+}
+
+void init_zeros_acc(acc_t * buf, int len) {
+    for (acc_t * ptr = buf; ptr < buf + len; ptr++) {
+        *ptr = 0;
+    }
+}
+
+int main() {
+#ifndef BAREMETAL
+    if (mlockall(MCL_CURRENT | MCL_FUTURE) != 0) {
+      perror("mlockall failed");
+      exit(1);
+    }
+#endif
+
+    gemmini_flush(0);
+
+    // assert((in_dim + 2*padding - kernel_dim) % stride == 0);
+
+    printf("Input dimensions (rows by columns): %u by %u\n", IN_ROW_DIM, IN_COL_DIM);
+    printf("Output dimensions (rows by columns): %u by %u\n\n", OUT_ROW_DIM, OUT_COL_DIM);
+
+    static elem_t input[BATCH_SIZE][IN_ROW_DIM][IN_COL_DIM][IN_STRIDE];
+    static elem_t weights[OUT_CHANNELS][KERNEL_DIM][KERNEL_DIM][IN_CHANNELS];
+    static acc_t bias[OUT_CHANNELS];
+    static elem_t output[BATCH_SIZE][OUT_ROW_DIM][OUT_COL_DIM][OUT_STRIDE];
+
+    printf("Randomize inputs...\n");
+    init_random(&input[0][0][0][0], BATCH_SIZE*IN_ROW_DIM*IN_COL_DIM, IN_CHANNELS, IN_STRIDE);
+
+    printf("Randomize weights...\n");
+    init_random(&weights[0][0][0][0], OUT_CHANNELS*KERNEL_DIM*KERNEL_DIM,IN_CHANNELS, IN_CHANNELS);
+
+    printf("Randomize bias...\n");
+    if (NO_BIAS)
+        init_zeros_acc(&bias[0], sizeof(bias) / sizeof(acc_t));
+    else
+        init_random_acc(&bias[0], sizeof(bias) / sizeof(acc_t));
+
+    printf("CPU conv...\n");
+    uint64_t start_cpu = read_cycles();
+    conv(BATCH_SIZE, IN_CHANNELS,
+            IN_ROW_DIM, IN_COL_DIM,
+            OUT_CHANNELS, KERNEL_DIM,
+            OUT_ROW_DIM, OUT_COL_DIM,
+            STRIDE, PADDING,
+            IN_STRIDE, OUT_STRIDE,
+            input,
+            weights,
+            bias,
+            output);
+    uint64_t end_cpu = read_cycles();
+    printf("CPU conv took %llu cycles\n", end_cpu - start_cpu);
+
+    static elem_t weights_mat[PATCH_SIZE][OUT_STRIDE] = {0};
+    static elem_t output_mat[N_PATCHES][OUT_STRIDE] = {0};
+
+    printf("Flatten weights...\n");
+    flatten_weights(OUT_CHANNELS, KERNEL_DIM, IN_CHANNELS,
+            PATCH_SIZE, OUT_STRIDE,
+            weights,
+            weights_mat);
+
+    printf("Gemmini conv...\n");
+    uint64_t start_gemmini = read_cycles();
+    tiled_conv_full(
+        BATCH_SIZE, IN_ROW_DIM, IN_COL_DIM, IN_CHANNELS,
+        OUT_CHANNELS, OUT_ROW_DIM, OUT_COL_DIM,
+        STRIDE, 1, 1, PADDING, KERNEL_DIM,
+        IN_STRIDE, WEIGHT_STRIDE, OUT_STRIDE,
+        false, false, false, false, false,
+
+        (elem_t*)input,
+        (elem_t*)weights_mat,
+        NO_BIAS ? NULL : (acc_t*)bias,
+        (elem_t*)output_mat,
+
+        NO_ACTIVATION, ACC_SCALE_IDENTITY, 0, 0, 0,
+
+        WS);
+    uint64_t end_gemmini = read_cycles();
+    printf("Gemmini conv took %llu cycles\n", end_gemmini - start_gemmini);
+
+    assert(sizeof(output_mat) == sizeof(output));
+
+    bool success = vec_is_equal(&output[0][0][0][0], &output_mat[0][0], sizeof(output) / sizeof(elem_t));
+    if (!success) {
+        // return 1;
+
+        printf("bias:\n");
+        for (int och = 0; och < OUT_CHANNELS; och++) {
+            printf("%d,", bias[och]);
+        }
+        printf("\b\n\n");
+
+        printf("weights:\n");
+        for (int och = 0; och < OUT_CHANNELS; och++) {
+            printf("[");
+            for (int wrow = 0; wrow < KERNEL_DIM; wrow++) {
+                printf("[");
+                for (int wcol = 0; wcol < KERNEL_DIM; wcol++) {
+                    printf("[");
+                    for (int ich = 0; ich < IN_CHANNELS; ich++) {
+                        printf("%d,", weights[och][wrow][wcol][ich]);
+                    }
+                    printf("\b],");
+                }
+                printf("\b],\n");
+            }
+            printf("\b],");
+        }
+        printf("\b\n\n");
+
+        printf("weights_mat:\n");
+        for (int wrow = 0; wrow < KERNEL_DIM * KERNEL_DIM * IN_CHANNELS; wrow++) {
+            printf("[");
+            for (int wcol = 0; wcol < OUT_STRIDE; wcol++) {
+                printf("%d,", weights_mat[wrow][wcol]);
+            }
+            printf("\b],\n");
+        }
+        printf("\b\n\n");
+
+        printf("input:\n");
+        for (int batch = 0; batch < BATCH_SIZE; batch++) {
+            printf("[");
+            for (int irow = 0; irow < IN_ROW_DIM; irow++) {
+                printf("[");
+                for (int icol = 0; icol < IN_COL_DIM; icol++) {
+                    printf("[");
+                    for (int ich = 0; ich < IN_STRIDE; ich++) {
+                        printf("%d,", input[batch][irow][icol][ich]);
+                    }
+                    printf("\b],");
+                }
+                printf("\b],\n");
+            }
+            printf("\b],");
+        }
+        printf("\b\n\n");
+
+        printf("output:\n");
+        for (int batch = 0; batch < BATCH_SIZE; batch++) {
+            printf("[");
+            for (int orow = 0; orow < OUT_ROW_DIM; orow++) {
+                printf("[");
+                for (int ocol = 0; ocol < OUT_COL_DIM; ocol++) {
+                    printf("[");
+                    for (int och = 0; och < OUT_STRIDE; och++) {
+                        printf("%d,", output[batch][orow][ocol][och]);
+                    }
+                    printf("\b],");
+                }
+                printf("\b],\n");
+            }
+            printf("\b],");
+        }
+        printf("\b\n\n");
+
+        printf("output_mat:\n");
+        for (int orow = 0; orow < BATCH_SIZE * OUT_ROW_DIM * OUT_COL_DIM; orow++) {
+            printf("[");
+            for (int ocol = 0; ocol < OUT_STRIDE; ocol++) {
+                printf("%d,", output_mat[orow][ocol]);
+            }
+            printf("\b],\n");
+        }
+        printf("\b\n\n");
+
+        return 1;
+    }
+
+    return 0;
+}

--- a/bareMetalC/gemmini_counter.c
+++ b/bareMetalC/gemmini_counter.c
@@ -108,7 +108,7 @@ int main() {
   gemmini_counter_access(counter_val, custom_command);
 
   printf("RESERVATION_STATION # of load insts after executing %d mvin and mvout insts: %d\n", N-1, counter_val);
-  if (counter_val < 3) {
+  if (counter_val < 2) {
     printf("The load RESERVATION_STATION counter value is too small\n");
     exit(1);
   }

--- a/bareMetalC/resadd_stride.c
+++ b/bareMetalC/resadd_stride.c
@@ -1,0 +1,107 @@
+// See LICENSE for license details.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#ifndef BAREMETAL
+#include <sys/mman.h>
+#endif
+#include "include/gemmini_testutils.h"
+
+#define CHECK_RESULT 1
+
+#ifndef BAREMETAL
+
+#define MAT_DIM_I 128
+#define MAT_DIM_J 251
+
+#else
+#define MAT_DIM_I 54
+#define MAT_DIM_J 27
+#endif
+
+#define J_STRIDE (MAT_DIM_J + 5)
+
+#define A_SCALE 2
+#define B_SCALE MVIN_SCALE_IDENTITY
+#define C_SCALE ACC_SCALE_IDENTITY
+#define USE_RELU true
+
+void full_printMatrix(elem_t m[MAT_DIM_I][J_STRIDE]) {
+  for (size_t i = 0; i < MAT_DIM_I; ++i) {
+    for (size_t j = 0; j < MAT_DIM_J; ++j)
+      printf("%d ", m[i][j]);
+    printf("\n");
+  }
+}
+
+int full_is_equal(elem_t x[MAT_DIM_I][J_STRIDE], elem_t y[MAT_DIM_I][J_STRIDE]) {
+  for (size_t i = 0; i < MAT_DIM_I; ++i)
+    for (size_t j = 0; j < MAT_DIM_J; ++j)
+      if (x[i][j] != y[i][j])
+        return 0;
+  return 1;
+}
+
+int main() {
+#ifndef BAREMETAL
+    if (mlockall(MCL_CURRENT | MCL_FUTURE) != 0) {
+      perror("mlockall failed");
+      exit(1);
+    }
+#endif
+
+    printf("I: %d, J: %d\n", MAT_DIM_I, MAT_DIM_J);
+
+    gemmini_flush(0);
+
+    static elem_t A[MAT_DIM_I][J_STRIDE] row_align(1) = {0};
+    static elem_t B[MAT_DIM_I][J_STRIDE] row_align(1) = {0};
+    static elem_t C[MAT_DIM_I][J_STRIDE] row_align(1) = {0};
+    static elem_t gold[MAT_DIM_I][J_STRIDE] = {0};
+
+#if CHECK_RESULT == 1
+    // printf("Init A and B\n");
+    for (size_t i = 0; i < MAT_DIM_I; ++i) {
+      for (size_t j = 0; j < MAT_DIM_J; ++j) {
+        A[i][j] = (rand() % 64) - 32;
+        B[i][j] = (rand() % 8) - 4;
+      }
+    }
+
+    printf("Starting slow CPU resadd\n");
+    unsigned long cpu_start = read_cycles();
+    resadd_cpu(MAT_DIM_I, MAT_DIM_J, J_STRIDE, A_SCALE, B_SCALE, C_SCALE, (elem_t*)A, (elem_t*)B,
+            (elem_t*)gold, USE_RELU);
+    unsigned long cpu_end = read_cycles();
+    printf("Cycles taken: %u\n", cpu_end-cpu_start);
+#endif
+
+    printf("Starting gemmini resadd\n");
+    unsigned long start = read_cycles();
+    tiled_resadd_stride_auto(MAT_DIM_I, MAT_DIM_J, A_SCALE, B_SCALE, C_SCALE, J_STRIDE, (elem_t*)A, (elem_t*)B,
+            (elem_t*)C, USE_RELU, WS);
+    unsigned long end = read_cycles();
+    printf("Cycles taken: %u\n", end-start);
+
+#if CHECK_RESULT == 1
+    if (!full_is_equal(C, gold)) {
+      printf("C:\n");
+      full_printMatrix(C);
+      printf("Gold:\n");
+      full_printMatrix(gold);
+      printf("A:\n");
+      full_printMatrix(A);
+      printf("B:\n");
+      full_printMatrix(B);
+      printf("\n");
+
+      exit(1);
+    }
+#endif
+
+  exit(0);
+}
+

--- a/imagenet/resnet50.c
+++ b/imagenet/resnet50.c
@@ -620,6 +620,7 @@ int main (int argc, char * argv[]) {
             conv_15_params.batch_size, conv_15_params.in_row_dim, conv_15_params.in_col_dim,
             conv_15_params.in_channels,
             conv_15_params.out_channels, conv_15_params.out_row_dim, conv_15_params.out_col_dim,
+            conv_15_params.in_channels, conv_15_params.out_channels, conv_15_params.out_channels,
             // conv_15_params.stride, 1, 1, conv_15_params.padding, conv_15_params.kernel_size,
             // false, false, false, false, false,
 
@@ -1101,6 +1102,7 @@ int main (int argc, char * argv[]) {
             conv_28_params.batch_size, conv_28_params.in_row_dim, conv_28_params.in_col_dim,
             conv_28_params.in_channels,
             conv_28_params.out_channels, conv_28_params.out_row_dim, conv_28_params.out_col_dim,
+            conv_28_params.in_channels, conv_28_params.out_channels, conv_28_params.out_channels,
             // conv_28_params.stride, 1, 1, conv_28_params.padding, conv_28_params.kernel_size,
             // false, false, false, false, false,
 

--- a/include/gemmini.h
+++ b/include/gemmini.h
@@ -2581,11 +2581,12 @@ static void tiled_conv_dw(
 }
 
 // need to specify each operand/output's stride
-static void tiled_conv_full(
+// stride only for trans == false, wrot == false
+static void tiled_conv_stride_auto(
         int batch_size, int in_row_dim, int in_col_dim, int in_channels,
         int out_channels, int out_row_dim, int out_col_dim,
         int stride, int input_dilation, int kernel_dilation, int padding, int kernel_dim,
-        int in_stride, int weight_stride, int out_stride,
+        int in_stride, int weight_stride, int out_stride, // specify in/output's stride
         bool wrot180, bool trans_output_1203, bool trans_input_3120,
         bool trans_weight_1203, bool trans_weight_0132,
 
@@ -2797,7 +2798,7 @@ static void tiled_conv_auto(
     int in_stride = in_channels;
     int out_stride = out_channels;
     int weight_stride = out_channels;
-    tiled_conv_full(
+    tiled_conv_stride_auto(
         batch_size, in_row_dim, in_col_dim, in_channels,
         out_channels, out_row_dim, out_col_dim,
         stride, input_dilation, kernel_dilation, padding, kernel_dim,
@@ -3176,7 +3177,7 @@ static void tiled_resadd(const size_t I, const size_t J,
 
 // Compute (A >> A_shift) + B = C
 // specify stride
-static void tiled_resadd_full(const size_t I, const size_t J,
+static void tiled_resadd_stride_auto(const size_t I, const size_t J,
         const scale_t A_scale,
         const scale_t B_scale,
         const acc_scale_t C_scale,
@@ -3232,7 +3233,7 @@ static void tiled_resadd_auto(const size_t I, const size_t J,
         elem_t * C,
         bool relu,
         enum tiled_matmul_type_t matadd_type) {
-    tiled_resadd_full(I, J, 
+    tiled_resadd_stride_auto(I, J, 
         A_scale, B_scale, C_scale,
         J,
         A, B, C,

--- a/include/gemmini.h
+++ b/include/gemmini.h
@@ -818,7 +818,7 @@ static void tiled_matmul_outer(size_t dim_I, size_t dim_J, size_t dim_K,
 
         if(a_reuse && j0 >= 1) a = NULL;
         if(b_reuse && i0 >= 1) b = NULL;
-        printf("a_reuse: %d, b_reuse: %d, a_spad_id: %d, b_spad_id: %d, a: %llu, b: %llu \n", a_reuse, b_reuse, a_spad_id, b_spad_id, a, b);
+        //printf("a_reuse: %d, b_reuse: %d, a_spad_id: %d, b_spad_id: %d, a: %llu, b: %llu \n", a_reuse, b_reuse, a_spad_id, b_spad_id, a, b);
         (*inner)(a, b, pre, out,
             A_scale_factor, B_scale_factor, D_scale_factor,
             I, J, K,
@@ -2408,7 +2408,7 @@ static void tiled_conv(
                                 }
                                 if(b_reuse && (pocol + (porow - porow_start) + b > 0)) weights_slice = NULL;
 							    if(a_reuse && (poch > 0)) in = NULL;
-                                printf("a_reuse: %d, b_reuse: %d, a_spad_id: %d, b_spad_id: %d, in: %llu, weight: %llu \n", a_reuse, b_reuse, a_spad_id, b_spad_id, in, weights_slice);
+                                //printf("a_reuse: %d, b_reuse: %d, a_spad_id: %d, b_spad_id: %d, in: %llu, weight: %llu \n", a_reuse, b_reuse, a_spad_id, b_spad_id, in, weights_slice);
  
                                 sp_tiled_conv(
                                     batch_size, in_row_dim, in_col_dim, in_channels,

--- a/include/gemmini.h
+++ b/include/gemmini.h
@@ -351,7 +351,7 @@ static void counter_reset() {
   }
 
 // weight-stationary conv loop
-#define gemmini_loop_conv_ws(batch_size, in_dim, in_channels, out_channels, out_dim, pool_out_dim, stride, padding, kernel_dim, kernel_dilation, pool_size, pool_stride, pool_padding, batches, porows, pocols, pochs, krows, kcols, kchs, lpad, rpad, upad, dpad, plpad, prpad, pupad, pdpad, orows, ocols, weights, output, bias, input, no_bias, no_pool, downsample, wrot180, input_dilated, activation, trans_output_1203, trans_weight_1203, trans_weight_0132, trans_input_3120, max_pixels_per_row, dw) \
+#define gemmini_loop_conv_ws(batch_size, in_dim, in_channels, out_channels, out_dim, pool_out_dim, stride, padding, kernel_dim, kernel_dilation, pool_size, pool_stride, pool_padding, batches, porows, pocols, pochs, krows, kcols, kchs, lpad, rpad, upad, dpad, plpad, prpad, pupad, pdpad, orows, ocols, weights, output, bias, input, no_bias, no_pool, downsample, wrot180, input_dilated, activation, trans_output_1203, trans_weight_1203, trans_weight_0132, trans_input_3120, max_pixels_per_row, in_stride, weight_stride, out_stride, dw) \
   { \
     ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(out_channels) << 48) | ((uint64_t)(in_channels) << 32) | ((uint64_t)(in_dim) << 16) | (uint64_t)(batch_size), \
       ((uint64_t)(padding) << 48) | ((uint64_t)(stride) << 32) | ((uint64_t)(pool_out_dim) << 16) | (uint64_t)(out_dim), k_LOOP_CONV_WS_CONFIG_1) \
@@ -359,8 +359,8 @@ static void counter_reset() {
       ((uint64_t)(batches) << 48) | ((uint64_t)(porows) << 32) | ((uint64_t)(pocols) << 16) | (uint64_t)(pochs), k_LOOP_CONV_WS_CONFIG_2) \
     ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(krows) << 48) | ((uint64_t)(kcols) << 32) | ((uint64_t)(kchs) << 16) | (uint64_t)(lpad), \
       ((uint64_t)(rpad) << 48) | ((uint64_t)(upad) << 32) | ((uint64_t)(dpad) << 16) | (uint64_t)(plpad), k_LOOP_CONV_WS_CONFIG_3) \
-    ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(orows) << 48) | ((uint64_t)(prpad) << 32) | ((uint64_t)(pupad) << 16) | (uint64_t)(pdpad), \
-      ((uint64_t)(kernel_dilation) << 16) | (uint64_t)(ocols), k_LOOP_CONV_WS_CONFIG_4) \
+    ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(orows) << 48) | ((uint64_t)(prpad) << 32) | ((uint64_t)(pupad) << 21) | ((uint64_t)(pdpad) << 10) | (uint64_t)(kernel_dilation), \
+      ((uint64_t)(in_stride) << 48) | ((uint64_t)(weight_stride) << 32) | ((uint64_t)(out_stride) << 16) | (uint64_t)(ocols), k_LOOP_CONV_WS_CONFIG_4) \
     ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, weights, \
       output, k_LOOP_CONV_WS_CONFIG_5) \
     ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, bias, \
@@ -1329,6 +1329,7 @@ static void sp_tiled_conv(
         int pool_out_row_dim, int pool_out_col_dim,
 
         int stride, int padding, int kernel_dim, int kernel_dilation,
+        int in_stride, int weight_stride, int out_stride,
 
         int pool_size, int pool_stride, int pool_padding,
 
@@ -1414,7 +1415,7 @@ static void sp_tiled_conv(
   }
 
   if (in_row_dim == in_col_dim && out_row_dim == out_col_dim && pool_out_row_dim == pool_out_col_dim) {
-    gemmini_loop_conv_ws(batch_size, in_row_dim, in_channels, out_channels, out_row_dim, pool_out_row_dim, stride, padding, kernel_dim, kernel_dilation, pool_size, pool_stride, pool_padding, batches, porows, pocols, pochs, krows, kcols, kchs, lpad, rpad, upad, dpad, plpad, prpad, pupad, pdpad, orows, ocols, weights, output, bias, input, no_bias, no_pool, downsample, wrot180, input_dilated, act, trans_output_1203, trans_weight_1203, trans_weight_0132, trans_input_3120, max_pixels_per_row, dw);
+    gemmini_loop_conv_ws(batch_size, in_row_dim, in_channels, out_channels, out_row_dim, pool_out_row_dim, stride, padding, kernel_dim, kernel_dilation, pool_size, pool_stride, pool_padding, batches, porows, pocols, pochs, krows, kcols, kchs, lpad, rpad, upad, dpad, plpad, prpad, pupad, pdpad, orows, ocols, weights, output, bias, input, no_bias, no_pool, downsample, wrot180, input_dilated, act, trans_output_1203, trans_weight_1203, trans_weight_0132, trans_input_3120, max_pixels_per_row, in_stride, weight_stride, out_stride, dw);
     return;
   }
 
@@ -1510,7 +1511,7 @@ static void sp_tiled_conv(
 
             const bool is_zeros = irow < 0 || irow >= irows_unpadded || icol < 0 || icol >= icols_unpadded;
 
-            const elem_t * in = input + (b*in_row_dim*in_col_dim + irow*in_col_dim + icol) * in_channels + ich;
+            const elem_t * in = input + (b*in_row_dim*in_col_dim + irow*in_col_dim + icol) * in_stride + ich;
             if (is_zeros) {
               in = NULL;
             } else if (trans_input_3120) {
@@ -1536,7 +1537,7 @@ static void sp_tiled_conv(
           MAX_BLOCK_LEN * DIM;
     }
 
-    size_t dram_stride = out_channels * sizeof(elem_t);
+    size_t dram_stride = weight_stride * sizeof(elem_t);
     if (dw) {
       dram_stride = sizeof(elem_t);
     } else if (trans_weight_1203) {
@@ -1569,7 +1570,7 @@ static void sp_tiled_conv(
               B_sp_addr = B_sp_addr_start + (kch / DIM) * krows * kcols * ochs + krow * kcols * ochs + kcol * ochs + och;
             }
 
-            const elem_t * w = weights + (krow*kernel_dim*in_channels + kcol*in_channels + kch) * out_channels + och;
+            const elem_t * w = weights + (krow*kernel_dim*in_channels + kcol*in_channels + kch) * weight_stride + och;
             if (dw) {
               w = weights + krow * kernel_dim + kcol;
             } else if (trans_weight_1203) {
@@ -1696,7 +1697,7 @@ static void sp_tiled_conv(
 
               const uint32_t C_sp_addr = C_sp_addr_start + (och / DIM) * batches * orows * ocols + b * orows * ocols + orow * ocols + ocol;
 
-              elem_t * out = output + (b*out_row_dim*out_col_dim + orow*out_col_dim + ocol) * out_channels + och;
+              elem_t * out = output + (b*out_row_dim*out_col_dim + orow*out_col_dim + ocol) * out_stride + och;
               if (trans_output_1203) {
                 out = output + (orow*out_col_dim*batch_size + ocol*batch_size + b) * out_channels + och;
               }
@@ -1811,6 +1812,7 @@ static void conv_cpu_without_pool(
         int batch_size, int in_row_dim, int in_col_dim, int in_channels,
         int out_channels, int out_row_dim, int out_col_dim,
         int stride, int input_dilation, int kernel_dilation, int padding, int kernel_dim,
+        int in_stride, int weight_stride, int out_stride,
         bool wrot180, bool trans_output_1203, bool trans_input_3120,
         bool trans_weight_1203, bool trans_weight_0132,
 
@@ -1843,7 +1845,7 @@ static void conv_cpu_without_pool(
               const int icol = (ocol * stride + kcol * kernel_dilation - padding) / input_dilation;
 
               for (int kch = 0; kch < in_channels; kch++) {
-                const elem_t *in = input + (b * in_row_dim * in_col_dim + irow * in_col_dim + icol) * in_channels + kch;
+                const elem_t *in = input + (b * in_row_dim * in_col_dim + irow * in_col_dim + icol) * in_stride + kch;
                 if (trans_input_3120) {
                   // NHWC to CHWN
                   in = input + (kch * in_row_dim * in_col_dim + irow * in_col_dim + icol) * batch_size + b;
@@ -1855,7 +1857,7 @@ static void conv_cpu_without_pool(
                 const int krow_ = wrot180 ? kernel_dim - krow - 1 : krow;
                 const int kcol_ = wrot180 ? kernel_dim - kcol - 1 : kcol;
 
-                elem_t weight = *(weights + (krow_ * kernel_dim * in_channels + kcol_ * in_channels + kch) * out_channels + och);
+                elem_t weight = *(weights + (krow_ * kernel_dim * in_channels + kcol_ * in_channels + kch) * weight_stride + och);
                 if (trans_weight_1203) {
                   // HWIO to WIHO
                   weight = *(weights + (kch * kernel_dim * kernel_dim  + krow_ * kernel_dim + kcol_) * out_channels + och);
@@ -1869,7 +1871,7 @@ static void conv_cpu_without_pool(
             }
           }
 
-          elem_t *out = output + (b * out_row_dim * out_col_dim + orow * out_col_dim + ocol) * out_channels + och;
+          elem_t *out = output + (b * out_row_dim * out_col_dim + orow * out_col_dim + ocol) * out_stride + och;
           if (trans_output_1203) {
             // NHWC to HWNC
             out = output + (orow * out_col_dim * batch_size + ocol * batch_size + b) * out_channels + och;
@@ -1934,6 +1936,7 @@ static void conv_cpu(
         int batch_size, int in_row_dim, int in_col_dim, int in_channels,
         int out_channels, int out_row_dim, int out_col_dim,
         int stride, int input_dilation, int kernel_dilation, int padding, int kernel_dim,
+        int in_stride, int weight_stride, int out_stride,
         bool wrot180, bool trans_output_1203, bool trans_input_3120,
         bool trans_weight_1203, bool trans_weight_0132,
 
@@ -1951,6 +1954,7 @@ static void conv_cpu(
         batch_size, in_row_dim, in_col_dim, in_channels,
         out_channels, out_row_dim, out_col_dim,
         stride, input_dilation, kernel_dilation, padding, kernel_dim,
+        in_stride, weight_stride, out_stride,
         wrot180, trans_output_1203, trans_input_3120,
         trans_weight_1203, trans_weight_0132,
         input, weights, bias, output,
@@ -1998,7 +2002,7 @@ static void conv_cpu(
                     const int icol = (ocol * stride + kcol * kernel_dilation - padding) / input_dilation;
 
                     for (int kch = 0; kch < in_channels; kch++) {
-                      const elem_t * in = input + (b * in_row_dim * in_col_dim + irow * in_col_dim + icol) * in_channels + kch;
+                      const elem_t * in = input + (b * in_row_dim * in_col_dim + irow * in_col_dim + icol) * in_stride + kch;
                       if (trans_input_3120) {
                         // NHWC to CHWN
                         in = input + (kch * in_row_dim * in_col_dim + irow * in_col_dim + icol) * batch_size + b;
@@ -2010,7 +2014,7 @@ static void conv_cpu(
                       const int krow_ = wrot180 ? kernel_dim - krow - 1 : krow;
                       const int kcol_ = wrot180 ? kernel_dim - kcol - 1 : kcol;
 
-                      elem_t weight = *(weights + (krow_ * kernel_dim * in_channels + kcol_ * in_channels + kch) * out_channels + poch);
+                      elem_t weight = *(weights + (krow_ * kernel_dim * in_channels + kcol_ * in_channels + kch) * weight_stride + poch);
                       if (trans_weight_1203) {
                         // HWIO to WIHO
                         weight = *(weights + (kch * kernel_dim * kernel_dim  + krow_ * kernel_dim + kcol_) * out_channels + poch);
@@ -2032,7 +2036,7 @@ static void conv_cpu(
               }
 
               if (pwrow == pool_size - 1 && pwcol == pool_size - 1) {
-                elem_t * out = output + (b * pool_out_row_dim * pool_out_col_dim + porow * pool_out_col_dim + pocol) * out_channels + poch;
+                elem_t * out = output + (b * pool_out_row_dim * pool_out_col_dim + porow * pool_out_col_dim + pocol) * out_stride + poch;
                 if (trans_output_1203) {
                   // NHWC to HWNC
                   out = output + (porow * pool_out_col_dim * batch_size + pocol * batch_size + b) * out_channels + poch;
@@ -2143,6 +2147,7 @@ static void tiled_conv(
         int in_row_dim, int in_col_dim, int in_channels,
         int out_channels, int out_row_dim, int out_col_dim,
         int stride, int input_dilation, int kernel_dilation, int padding, int kernel_dim,
+        int in_stride, int weight_stride, int out_stride,
         bool wrot180, bool trans_output_1203, bool trans_input_3120,
         bool trans_weight_1203, bool trans_weight_0132,
 
@@ -2178,6 +2183,7 @@ static void tiled_conv(
         batch_size, in_row_dim, in_col_dim, in_channels,
         out_channels, out_row_dim, out_col_dim,
         stride, input_dilation, kernel_dilation, padding, kernel_dim,
+        in_stride, weight_stride, out_stride,
         wrot180, trans_output_1203, trans_input_3120,
         trans_weight_1203, trans_weight_0132,
         input, weights, bias, output,
@@ -2255,7 +2261,7 @@ static void tiled_conv(
 
     const size_t st_dram_stride = trans_output_1203 ?
         batch_size * out_channels * sizeof(elem_t) :
-        out_channels * sizeof(elem_t);
+        out_stride * sizeof(elem_t);
     gemmini_extended_config_st(st_dram_stride, act, scale);
 
     gemmini_extended3_config_ex(WEIGHT_STATIONARY, 0, 0, 0, input_dilation, stride >> downsample, trans_input_3120, trans_weight_0132, false);
@@ -2282,7 +2288,7 @@ static void tiled_conv(
                             int icol = ocol_floored * stride + kcol * kernel_dilation - padding;
 
                             for (int kch = 0; kch < in_channels; kch += kchs) {
-                                elem_t * out = output + (b * pool_out_row_dim * pool_out_col_dim + porow * pool_out_col_dim + pocol) * out_channels + poch;
+                                elem_t * out = output + (b * pool_out_row_dim * pool_out_col_dim + porow * pool_out_col_dim + pocol) * out_stride + poch;
                                 if (trans_output_1203) {
                                     out = output + (porow * pool_out_col_dim * batch_size + pocol * batch_size + b) * out_channels + poch;
                                 }
@@ -2341,14 +2347,14 @@ static void tiled_conv(
                                   kcol_ = kernel_dim - kcol - kcols_;
                                 }
 
-                                const elem_t * weights_slice = weights + (krow_*kernel_dim*in_channels + kcol_*in_channels + kch) * out_channels + poch;
+                                const elem_t * weights_slice = weights + (krow_*kernel_dim*in_channels + kcol_*in_channels + kch) * weight_stride + poch;
                                 if (trans_weight_1203) {
                                   weights_slice = weights + (kch*kernel_dim*kernel_dim + krow_*kernel_dim+kcol_) * out_channels + poch;
                                 } else if (trans_weight_0132) {
                                   weights_slice = weights + (krow_*kernel_dim*out_channels + kcol_*out_channels + poch) * in_channels + kch;
                                 }
 
-                                const elem_t * in = input + (b *in_row_dim * in_col_dim + ((irow+upad)>>input_dilated) * in_col_dim + ((icol+lpad)>>input_dilated)) * in_channels + kch;
+                                const elem_t * in = input + (b *in_row_dim * in_col_dim + ((irow+upad)>>input_dilated) * in_col_dim + ((icol+lpad)>>input_dilated)) * in_stride + kch;
                                 if (trans_input_3120) {
                                   in = input + (kch * in_row_dim * in_col_dim + ((irow+upad)>>input_dilated) * in_col_dim + ((icol+lpad)>>input_dilated)) * batch_size + b;
                                 }
@@ -2359,6 +2365,7 @@ static void tiled_conv(
                                     pool_out_row_dim, pool_out_col_dim,
 
                                     stride, padding, kernel_dim, kernel_dilation,
+                                    in_stride, weight_stride, out_stride,
 
                                     pool_size, pool_stride, pool_padding,
 
@@ -2541,6 +2548,7 @@ static void tiled_conv_dw(
                                 pool_out_row_dim, pool_out_col_dim,
 
                                 stride, padding, kernel_dim, 1,
+                                channels, 1, channels,
 
                                 pool_size, pool_stride, pool_padding,
 
@@ -2572,11 +2580,12 @@ static void tiled_conv_dw(
     }
 }
 
-
-static void tiled_conv_auto(
+// need to specify each operand/output's stride
+static void tiled_conv_full(
         int batch_size, int in_row_dim, int in_col_dim, int in_channels,
         int out_channels, int out_row_dim, int out_col_dim,
         int stride, int input_dilation, int kernel_dilation, int padding, int kernel_dim,
+        int in_stride, int weight_stride, int out_stride,
         bool wrot180, bool trans_output_1203, bool trans_input_3120,
         bool trans_weight_1203, bool trans_weight_0132,
 
@@ -2748,6 +2757,7 @@ static void tiled_conv_auto(
         batch_size, in_row_dim, in_col_dim, in_channels,
         out_channels, out_row_dim, out_col_dim,
         stride, input_dilation, kernel_dilation, padding, kernel_dim,
+        in_stride, weight_stride, out_stride,
         wrot180, trans_output_1203, trans_input_3120,
         trans_weight_1203, trans_weight_0132,
 
@@ -2767,10 +2777,46 @@ static void tiled_conv_auto(
 }
 
 
+static void tiled_conv_auto(
+        int batch_size, int in_row_dim, int in_col_dim, int in_channels,
+        int out_channels, int out_row_dim, int out_col_dim,
+        int stride, int input_dilation, int kernel_dilation, int padding, int kernel_dim, 
+        bool wrot180, bool trans_output_1203, bool trans_input_3120,
+        bool trans_weight_1203, bool trans_weight_0132,
+
+        const elem_t * input,
+        const elem_t * weights,
+        const acc_t * bias,
+        elem_t * output,
+
+        int act, acc_scale_t scale,
+        int pool_size, int pool_stride, int pool_padding,
+
+        enum tiled_matmul_type_t tiled_conv_type) {
+
+    int in_stride = in_channels;
+    int out_stride = out_channels;
+    int weight_stride = out_channels;
+    tiled_conv_full(
+        batch_size, in_row_dim, in_col_dim, in_channels,
+        out_channels, out_row_dim, out_col_dim,
+        stride, input_dilation, kernel_dilation, padding, kernel_dim,
+        in_stride, weight_stride, out_stride,
+        wrot180, trans_output_1203, trans_input_3120,
+        trans_weight_1203, trans_weight_0132,
+        
+        input, weights, bias, output,
+
+        act, scale, pool_size, pool_stride, pool_padding,
+        tiled_conv_type);
+
+}
+
 // This function is for a convolution with kernel_dim=1, stride==2, padding=0, and no pooling
 static void tiled_conv_downsample(
         int batch_size, int in_row_dim, int in_col_dim, int in_channels,
         int out_channels, int out_row_dim, int out_col_dim,
+        int in_stride, int weight_stride, int out_stride,
 
         const elem_t * input,
         const elem_t * weights,
@@ -2800,15 +2846,15 @@ static void tiled_conv_downsample(
             const int J = out_channels;
             const int K = in_channels;
 
-            const elem_t * A = input + (b * in_dim + irow) * in_dim * in_channels;
+            const elem_t * A = input + (b * in_dim + irow) * in_dim * in_stride;
             const elem_t * B = weights;
             const acc_t * D = bias;
-            elem_t * C = output + (b * out_dim + orow) * out_dim * out_channels;
+            elem_t * C = output + (b * out_dim + orow) * out_dim * out_stride;
 
-            const int A_stride = in_channels * 2;
-            const int B_stride = out_channels;
-            const int D_stride = out_channels;
-            const int C_stride = out_channels;
+            const int A_stride = in_stride * 2;
+            const int B_stride = weight_stride;
+            const int D_stride = out_stride;
+            const int C_stride = out_stride;
 
             tiled_matmul_auto(I, J, K, A, B, (void*)D, (void*)C,
                     A_stride, B_stride, D_stride, C_stride,
@@ -3004,6 +3050,7 @@ static void tiled_conv_dw_auto(
 
 
 static void resadd_cpu(const size_t I, const size_t J,
+        const size_t stride,
         const scale_t A_scale,
         const scale_t B_scale,
         const acc_scale_t C_scale,
@@ -3016,9 +3063,9 @@ static void resadd_cpu(const size_t I, const size_t J,
 
     for (size_t i = 0; i < I; i++) {
         for (size_t j = 0; j < J; j++) {
-            const elem_t * a = A + i * J + j;
-            const elem_t * b = B + i * J + j;
-            elem_t * c = C + i * J + j;
+            const elem_t * a = A + i * stride + j;
+            const elem_t * b = B + i * stride + j;
+            elem_t * c = C + i * stride + j;
 
             acc_t result = MVIN_SCALE(*a, A_scale) + MVIN_SCALE(*b, B_scale);
             result = ACC_SCALE(result, C_scale);
@@ -3091,6 +3138,7 @@ static void sp_tiled_resadd(const size_t I, const size_t J,
 
 // Compute MVIN_SCALE(A, A_scale) + MVIN_SCALE(B, B_scale) = C
 static void tiled_resadd(const size_t I, const size_t J,
+        const size_t stride,
         const size_t tile_I, const size_t tile_J,
         const scale_t A_scale,
         const scale_t B_scale,
@@ -3101,24 +3149,24 @@ static void tiled_resadd(const size_t I, const size_t J,
         bool relu,
         enum tiled_matmul_type_t matadd_type) {
 
-    gemmini_extended_config_st(J * sizeof(elem_t), relu ? RELU : NO_ACTIVATION, C_scale);
+    gemmini_extended_config_st(stride * sizeof(elem_t), relu ? RELU : NO_ACTIVATION, C_scale);
     gemmini_config_ex(WS, 0, 0);
 
-    gemmini_extended4_config_ld(J * sizeof(elem_t), A_scale, true, DIM, 0);
-    gemmini_extended4_config_ld(J * sizeof(elem_t), B_scale, true, DIM, 1);
+    gemmini_extended4_config_ld(stride * sizeof(elem_t), A_scale, true, DIM, 0);
+    gemmini_extended4_config_ld(stride * sizeof(elem_t), B_scale, true, DIM, 1);
 
     for (size_t i = 0; i < I; i += tile_I) {
         for (size_t j = 0; j < J; j += tile_J) {
             const size_t I_tile = i + tile_I <= I ? tile_I : I - i;
             const size_t J_tile = j + tile_J <= J ? tile_J : J - j;
 
-            const elem_t * a = A + i * J + j;
-            const elem_t * b = B + i * J + j;
-            elem_t * c = C + i * J + j;
+            const elem_t * a = A + i * stride + j;
+            const elem_t * b = B + i * stride + j;
+            elem_t * c = C + i * stride + j;
 
             sp_tiled_resadd(I_tile, J_tile,
                     A_scale, B_scale, a, b, c,
-                    J, J, J,
+                    stride, stride, stride,
                     relu);
         }
     }
@@ -3127,10 +3175,12 @@ static void tiled_resadd(const size_t I, const size_t J,
 }
 
 // Compute (A >> A_shift) + B = C
-static void tiled_resadd_auto(const size_t I, const size_t J,
+// specify stride
+static void tiled_resadd_full(const size_t I, const size_t J,
         const scale_t A_scale,
         const scale_t B_scale,
         const acc_scale_t C_scale,
+        const size_t stride,
         const elem_t * A,
         const elem_t * B,
         elem_t * C,
@@ -3138,7 +3188,7 @@ static void tiled_resadd_auto(const size_t I, const size_t J,
         enum tiled_matmul_type_t matadd_type) {
 
     if (matadd_type == CPU) {
-        resadd_cpu(I, J,
+        resadd_cpu(I, J, stride,
             A_scale, B_scale, C_scale, A, B, C,
             relu);
         return;
@@ -3163,12 +3213,9 @@ static void tiled_resadd_auto(const size_t I, const size_t J,
     // printf("tile_J: %llu\n", tile_J);
 
     if (matadd_type == WS) {
-      tiled_resadd(I, J, tile_I, tile_J,
+      tiled_resadd(I, J, stride, tile_I, tile_J,
             A_scale, B_scale, C_scale, A, B, C,
             relu, matadd_type);
-    } else if(matadd_type == CPU){
-	  resadd_cpu(I, J, A_scale, B_scale, C_scale,
-		A, B, C, relu);
     }
     else {
       printf("Unsupported type\n");
@@ -3176,6 +3223,21 @@ static void tiled_resadd_auto(const size_t I, const size_t J,
     }
 }
 
+static void tiled_resadd_auto(const size_t I, const size_t J,
+        const scale_t A_scale,
+        const scale_t B_scale,
+        const acc_scale_t C_scale,
+        const elem_t * A,
+        const elem_t * B,
+        elem_t * C,
+        bool relu,
+        enum tiled_matmul_type_t matadd_type) {
+    tiled_resadd_full(I, J, 
+        A_scale, B_scale, C_scale,
+        J,
+        A, B, C,
+        relu, matadd_type);
+}
 
 static void global_average_cpu(const elem_t * input, elem_t * output,
     int batches, int channels, int dim) {

--- a/include/gemmini_nn.h
+++ b/include/gemmini_nn.h
@@ -19,6 +19,9 @@ struct ConvParams {
     int kernel_size;
     int in_channels;
     int out_channels;
+    int in_stride;
+    int weight_stride;
+    int out_stride;
     int stride;
     int padding;
     bool bias;
@@ -120,7 +123,8 @@ static void tiled_matmul_nn(size_t dim_I, size_t dim_J, size_t dim_K,
 
 // This function runs a tiled matrix multiplication, with automatically
 // calculated tiling factors
-static void tiled_matmul_nn_auto(size_t dim_I, size_t dim_J, size_t dim_K,
+// With default auto-stride calc (A_stride = dim_K, B_stride/C_stride/D_stride = dim_J)
+static void tiled_matmul_nn_auto(size_t dim_I, size_t dim_J, size_t dim_K, 
         const elem_t A[dim_I][dim_K], const elem_t B[dim_K][dim_J],
         const void * D, elem_t C[dim_I][dim_J],
         int act, acc_scale_t scale, bool repeating_bias,
@@ -131,7 +135,7 @@ static void tiled_matmul_nn_auto(size_t dim_I, size_t dim_J, size_t dim_K,
         printf("%s: gemmini\n", layer_name);
 
     tiled_matmul_auto(dim_I, dim_J, dim_K,
-        (elem_t*)A, (elem_t*)B, D, (elem_t*)C, 
+        (elem_t*)A, (elem_t*)B, D, (elem_t*)C,
         dim_K, dim_J, dim_J, dim_J,
         MVIN_SCALE_IDENTITY, MVIN_SCALE_IDENTITY, MVIN_SCALE_IDENTITY,
         act, scale, 0, repeating_bias,
@@ -160,6 +164,25 @@ static void tiled_matmul_nn_auto(size_t dim_I, size_t dim_J, size_t dim_K,
     }
 }
 
+// need to specify stride
+// auto tiling calc
+static void tiled_matmul_nn_full(size_t dim_I, size_t dim_J, size_t dim_K,
+        const size_t A_stride, const size_t B_stride, const size_t C_stride,
+        const elem_t * A, const elem_t * B, const void * D, const elem_t * C,
+        int act, acc_scale_t scale, bool repeating_bias,
+        enum tiled_matmul_type_t tiled_matmul_type)
+{
+
+    tiled_matmul_auto(dim_I, dim_J, dim_K,
+        (elem_t*)A, (elem_t*)B, D, (elem_t*)C,
+        A_stride, B_stride, C_stride, C_stride,
+        MVIN_SCALE_IDENTITY, MVIN_SCALE_IDENTITY, MVIN_SCALE_IDENTITY,
+        act, scale, 0, repeating_bias,
+        false, false,
+        false, false,
+        0,
+        tiled_matmul_type);
+}
 static void conv_dw(size_t I, size_t J,
     const size_t batch_size, const size_t channels,
     const size_t in_row_dim, const size_t in_col_dim,

--- a/include/gemmini_nn.h
+++ b/include/gemmini_nn.h
@@ -166,7 +166,7 @@ static void tiled_matmul_nn_auto(size_t dim_I, size_t dim_J, size_t dim_K,
 
 // need to specify stride
 // auto tiling calc
-static void tiled_matmul_nn_full(size_t dim_I, size_t dim_J, size_t dim_K,
+static void tiled_matmul_nn_stride_auto(size_t dim_I, size_t dim_J, size_t dim_K,
         const size_t A_stride, const size_t B_stride, const size_t C_stride,
         const elem_t * A, const elem_t * B, const void * D, const elem_t * C,
         int act, acc_scale_t scale, bool repeating_bias,


### PR DESCRIPTION
Add in/out/weight stride (tiled_conv_stride_auto, tiled_resadd_stride_auto)
Add input operands (A, B) reusing options for tiled_matmul and tiled_conv based on the operand size