### PR TITLE
Add move to scratchpad instruction

### DIFF
--- a/bareMetalC/Makefile
+++ b/bareMetalC/Makefile
@@ -67,6 +67,8 @@ else
 # Don't run very long benchmarks for RTL sim
 runs_baremetal = $(addsuffix .run,$(filter-out tiled_matmul_cpu-baremetal tiled_matmul_option-baremetal,$(tests_baremetal)))
 endif
+# Nornaml configs dont have ext spad
+runs_baremetal := $(filter-out matmul_spad-baremetal.run mvin_mvout_spad-baremetal.run,$(runs_baremetal))
 
 ifdef BAREMETAL_ONLY
 	tests_linux =

--- a/bareMetalC/Makefile
+++ b/bareMetalC/Makefile
@@ -10,6 +10,7 @@ tests = \
 	mvin_mvout_acc_stride \
 	mvin_mvout_acc_full \
 	mvin_mvout_acc_full_stride \
+	mvin_mvout_spad \
 	matmul_os \
 	matmul_ws \
 	matmul \

--- a/bareMetalC/Makefile
+++ b/bareMetalC/Makefile
@@ -14,6 +14,7 @@ tests = \
 	matmul_os \
 	matmul_ws \
 	matmul \
+	matmul_spad \
 	raw_hazard \
 	aligned \
 	padded \

--- a/bareMetalC/matmul_spad.c
+++ b/bareMetalC/matmul_spad.c
@@ -14,6 +14,8 @@
 
 static elem_t ZERO[DIM][DIM];
 
+#define FAST
+
 #ifdef FAST
 #define AINIT RELU
 #define SINIT 4
@@ -177,10 +179,12 @@ void test_os (bool A_transpose, bool B_transpose) {
       // printf("Moving out\n");
       for (size_t c = 0; c < N*N*N; ++c)
         if (!no_output[c]) {
-          gemmini_mvout(C[c], C_addr + c*DIM);
+          gemmini_mvout_spad(C_addr + c*DIM + N*N*N * DIM, C_addr + c*DIM); // mvout to spad, then to dram
+          gemmini_mvout(C[c], C_addr + c*DIM + N*N*N * DIM);
         }
 
       gemmini_fence();
+      printf("moved out\n");
 
       /*
       printf("Moved out\n");
@@ -384,7 +388,9 @@ void test_ws(bool A_transpose, bool B_transpose) {
       // printf("Moving out\n");
       for (size_t c = 0; c < N*N*N; ++c)
         if (!no_output[c]) {
-          gemmini_mvout(C[c], C_addrs[c] & ~(1 << (ADDR_LEN-2)));
+          uint32_t addr = C_addrs[c] & ~(1 << (ADDR_LEN-2));
+          gemmini_mvout_spad(c * DIM, addr);
+          gemmini_mvout(C[c], c * DIM);
         }
 
       gemmini_fence();

--- a/bareMetalC/mvin_mvout_spad.c
+++ b/bareMetalC/mvin_mvout_spad.c
@@ -105,7 +105,7 @@ int main() {
       for (size_t n = 0; n < N; ++n) {
         // printf("Mvin n: %u\n", n);
         gemmini_mvin(In[n], acc_addr + n*DIM);
-        gemmini_mvout_spad(spad_addr + n*DIM, acc_addr + n*DIM, DIM, DIM);
+        gemmini_mvout_spad(spad_addr + n*DIM, acc_addr + n*DIM);
 //        gemmini_fence();
 //        printf("Mvout n: %u\n", n);
         gemmini_mvout(Out[n], spad_addr + n*DIM);

--- a/bareMetalC/mvin_mvout_spad.c
+++ b/bareMetalC/mvin_mvout_spad.c
@@ -1,0 +1,145 @@
+// See LICENSE for license details.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#ifndef BAREMETAL
+#include <sys/mman.h>
+#endif
+#include "include/gemmini_testutils.h"
+
+#define FAST
+
+#ifdef FAST
+#define N 2
+#define AINIT RELU
+#define SINIT 12
+#else
+#define N 4
+#define AINIT NO_ACTIVATION
+#define SINIT 12
+#endif
+
+#if (N*DIM) > ACC_ROWS
+#error not enough accumulator space
+#endif
+
+#if (N*DIM) > BANK_ROWS
+#error not enough scratchpad space
+#endif
+
+int main() {
+#ifndef BAREMETAL
+    if (mlockall(MCL_CURRENT | MCL_FUTURE) != 0) {
+      perror("mlockall failed");
+      exit(1);
+    }
+#endif
+
+  gemmini_flush(0);
+
+  for (int activation = AINIT; activation <= RELU; ++activation) {
+    for (int scale = SINIT; scale <= 12; scale += 4) {
+      // printf("activation: %d, scale: %d\n", activation, scale);
+
+      static acc_t In[N][DIM][DIM] row_align_acc(1);
+      static full_t In_full[N][DIM][DIM];
+      static elem_t Out[N][DIM][DIM] row_align(1);
+      static elem_t Out_gold[N][DIM][DIM];
+
+      // printf("Initializing matrices\n");
+      for (size_t n = 0; n < N; ++n)
+        for (size_t i = 0; i < DIM; ++i)
+          for (size_t j = 0; j < DIM; ++j) {
+#ifndef ELEM_T_IS_FLOAT
+            In[n][i][j] = 0;
+#ifdef FAST
+#define RAND (j + i)
+#else
+#define RAND rand()
+#endif
+            int bytes = RAND % 2 ? sizeof(acc_t) : sizeof(elem_t);
+            for (size_t b = 0; b < bytes; ++b) {
+              In[n][i][j] |= (RAND % 255) << (b*8);
+            }
+#else
+            acc_t_bits data;
+
+            do {
+              data = 0;
+
+              int bytes = rand() % 2 ? sizeof(acc_t) : sizeof(elem_t);
+              for (size_t b = 0; b < bytes; ++b) {
+                data |= (uint64_t)(rand() % 255) << (b*8);
+              }
+
+              In[n][i][j] = acc_t_bits_to_acc_t(data);
+            } while (acc_t_isnan(In[n][i][j]));
+#endif
+
+            In_full[n][i][j] = In[n][i][j];
+          }
+
+      // printf("Shifting and activating matrices\n");
+      for (size_t n = 0; n < N; ++n) {
+        matscale(In_full[n], Out_gold[n], scale);
+
+        if (activation == RELU)
+          matrelu(Out_gold[n], Out_gold[n]);
+      }
+
+      const uint32_t acc_addr = 1 << (ADDR_LEN-1);
+      const uint32_t spad_addr = 0;
+
+      // printf("Config\n");
+      gemmini_config_ld(DIM*sizeof(acc_t));
+      gemmini_config_ex(0, 0, 0);
+      gemmini_extended_config_st(DIM*sizeof(elem_t), activation, scale);
+
+      // printf("Mvin and mvout\n");
+      printf("acc addr: %x\n", acc_addr);
+      printf("spad addr: %x\n", spad_addr);
+      printf("out addr: %p\n", &Out[0]);
+      for (size_t n = 0; n < N; ++n) {
+        // printf("Mvin n: %u\n", n);
+        gemmini_mvin(In[n], acc_addr + n*DIM);
+        gemmini_mvout_spad(spad_addr + n*DIM, acc_addr + n*DIM, DIM, DIM);
+//        gemmini_fence();
+//        printf("Mvout n: %u\n", n);
+        gemmini_mvout(Out[n], spad_addr + n*DIM);
+      }
+
+      printf("Fence\n");
+      gemmini_fence();
+
+      printf("Check\n");
+      for (size_t n = 0; n < N; ++n)
+        if (!is_equal(Out[n], Out_gold[n])) {
+          printf("activation: %d, scale: %d\n", activation, scale);
+
+          printf("Matrix %u:\n", n);
+          for (size_t i = 0; i < DIM; ++i) {
+            for (size_t j = 0; j < DIM; ++j)
+#ifndef ELEM_T_IS_FLOAT
+              printf("%d ", In[n][i][j]);
+#else
+              printf("%llx ", acc_t_to_acc_t_bits(In[n][i][j]));
+#endif
+            printf("\n");
+          }
+          printf("Matrix %u output:\n", n);
+          printMatrix(Out[n]);
+          printf("Matrix %u gold output:\n", n);
+          printMatrix(Out_gold[n]);
+          printf("\n");
+
+          exit(1);
+        }
+    }
+  }
+
+  exit(0);
+}
+

--- a/include/gemmini.h
+++ b/include/gemmini.h
@@ -367,12 +367,11 @@ int ceil_divide_int(int a, int b){
     ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(a_spad_id) << 18) | ((uint64_t)(b_spad_id) << 16) | ((uint64_t)(act) << 8) | ((low_D) << 2) | ((full_C) << 1) | (ex_accumulate), ((is_resadd) << 2) | ((B_transpose) << 1) | (A_transpose), k_LOOP_WS) \
   }
 
-#define gemmini_loop_ws_spad(I, J, K, pad_I, pad_J, pad_K, A, B, D, C, A_transpose, B_transpose, full_C, _low_D, ex_accumulate, act, a_spad_id, b_spad_id, is_resadd) \
+#define gemmini_loop_ws_spad(I, J, K, pad_I, pad_J, pad_K, A, B, D, C, A_transpose, B_transpose, full_C, low_D, ex_accumulate, act, a_spad_id, b_spad_id, is_resadd, skips) \
   { \
     ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(pad_K) << 32) | ((uint64_t)(pad_J) << 16) | (uint64_t)(pad_I), ((uint64_t)(K) << 32) | ((uint64_t)(J) << 16) | (uint64_t)(I), k_LOOP_WS_CONFIG_BOUNDS) \
     ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, A, B, k_LOOP_WS_CONFIG_SPAD_AB) \
-    ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, C, 0, k_LOOP_WS_CONFIG_SPAD_C) \
-    ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(a_spad_id) << 18) | ((uint64_t)(b_spad_id) << 16) | ((uint64_t)(act) << 8) | ((low_D) << 2) | ((full_C) << 1) | (ex_accumulate), ((is_resadd) << 2) | ((B_transpose) << 1) | (A_transpose), k_LOOP_WS) \
+    ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(a_spad_id) << 18) | ((uint64_t)(b_spad_id) << 16) | ((uint64_t)(act) << 8) | ((low_D) << 2) | ((full_C) << 1) | (ex_accumulate), ((uint64_t)(C) << 32) | 0x200U | (skips) | ((is_resadd) << 2) | ((B_transpose) << 1) | (A_transpose), k_LOOP_WS) \
   }
 
 // weight-stationary conv loop

--- a/include/gemmini.h
+++ b/include/gemmini.h
@@ -227,8 +227,8 @@ static acc_scale_t_bits acc_scale_t_to_acc_scale_t_bits(acc_scale_t x) {
 #define gemmini_extended_mvout_spad(dst_addr, dst_stride, src_addr, cols, rows) \
   ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(dst_stride) << 32) | (uint64_t)(dst_addr), ((uint64_t)(rows) << (ADDR_LEN + 16)) | ((uint64_t)(cols) << ADDR_LEN) | (uint64_t)(src_addr), k_MVOUT_SPAD)
 
-#define gemmini_mvout_spad(dst_addr, src_addr, cols, rows) \
-  gemmini_extended_mvout_spad(dst_addr, 1, src_addr, cols, rows)
+#define gemmini_mvout_spad(dst_addr, src_addr) \
+  gemmini_extended_mvout_spad(dst_addr, 1, src_addr, DIM, DIM)
 
 #define gemmini_mvout(dram_addr, spad_addr) \
   gemmini_extended_mvout(dram_addr, spad_addr, DIM, DIM)
@@ -1050,6 +1050,7 @@ static void matmul_cpu(bool transA, bool transB, size_t DIM_I, size_t DIM_J, siz
           *c = scale_and_sat(sum, act, scale, bert_scale);
       }
 
+#ifdef HAS_NORMALIZATIONS
       if (act == LAYERNORM) {
         acc_t sum = 0;
         for (size_t j = 0; j < DIM_J; j++)
@@ -1107,6 +1108,7 @@ static void matmul_cpu(bool transA, bool transB, size_t DIM_I, size_t DIM_J, siz
           *c = scale_and_sat(c_buffer[j], act, factor, bert_scale);
         }
       }
+#endif
     }
   }
 }

--- a/include/gemmini.h
+++ b/include/gemmini.h
@@ -194,8 +194,16 @@ static acc_scale_t_bits acc_scale_t_to_acc_scale_t_bits(acc_scale_t x) {
     return un.b;
 }
 
-#define ROCC_INSTRUCTION_RS1_RS2(x, rs1, rs2, funct) \
-  ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, funct)
+#define ROCC_INSTRUCTION_RS1_RS2(x, rs1, rs2, funct) { \
+    printf("function %d\n", funct); \
+    uint32_t instruction = (0x7B) | (0 << 7) | (3 << 12) | (1 << 15) | (2 << 20) | ((uint32_t) funct << 25); \
+    *((uint64_t*) 0x60000010) = (uint64_t) (rs1); \
+    *((uint64_t*) 0x60000018) = (uint64_t) (rs2); \
+    gemmini_fence(); \
+    *((uint32_t*) 0x60000000) = instruction; \
+}
+//#define ROCC_INSTRUCTION_RS1_RS2(x, rs1, rs2, funct) \
+//  ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, funct)
 
 // mvin and mvout
 #define gemmini_extended_mvin(dram_addr, spad_addr, cols, rows) \

--- a/include/gemmini.h
+++ b/include/gemmini.h
@@ -50,6 +50,9 @@
 #define k_LOOP_CONV_WS_CONFIG_5 20
 #define k_LOOP_CONV_WS_CONFIG_6 21
 
+// CLKGATE_EN: 22
+#define k_MVOUT_SPAD 23
+
 #define CONFIG_EX 0
 #define CONFIG_LD 1
 #define CONFIG_ST 2
@@ -212,6 +215,12 @@ static acc_scale_t_bits acc_scale_t_to_acc_scale_t_bits(acc_scale_t x) {
 
 #define gemmini_extended_mvout(dram_addr, spad_addr, cols, rows) \
   ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, dram_addr, ((uint64_t)(rows) << (ADDR_LEN + 16)) | ((uint64_t)(cols) << ADDR_LEN) | (uint64_t)(spad_addr), k_MVOUT)
+
+#define gemmini_extended_mvout_spad(dst_addr, dst_stride, src_addr, cols, rows) \
+  ROCC_INSTRUCTION_RS1_RS2(XCUSTOM_ACC, ((uint64_t)(dst_stride) << 32) | (uint64_t)(dst_addr), ((uint64_t)(rows) << (ADDR_LEN + 16)) | ((uint64_t)(cols) << ADDR_LEN) | (uint64_t)(src_addr), k_MVOUT_SPAD)
+
+#define gemmini_mvout_spad(dst_addr, src_addr, cols, rows) \
+  gemmini_extended_mvout_spad(dst_addr, 1, src_addr, cols, rows)
 
 #define gemmini_mvout(dram_addr, spad_addr) \
   gemmini_extended_mvout(dram_addr, spad_addr, DIM, DIM)

--- a/include/gemmini_params.h
+++ b/include/gemmini_params.h
@@ -5,26 +5,35 @@
 #include <limits.h>
 
 #define XCUSTOM_ACC 3
-#define DIM 16
+#define DIM 8
 #define ADDR_LEN 32
 #define BANK_NUM 4
-#define BANK_ROWS 4096
-#define ACC_ROWS 1024
+#define BANK_ROWS 128
+#define ACC_ROWS 256
 #define MAX_BYTES 64
-#define MAX_BLOCK_LEN (MAX_BYTES/(DIM*1))
+#define MAX_BLOCK_LEN (MAX_BYTES/(DIM*4))
 #define MAX_BLOCK_LEN_ACC (MAX_BYTES/(DIM*4))
 
-typedef int8_t elem_t;
-static const elem_t elem_t_max = 127;
-static const elem_t elem_t_min = -128;
-typedef int32_t acc_t;
-typedef int64_t full_t;
+typedef float elem_t;
+static const elem_t elem_t_max = 3.4028235E38;
+static const elem_t elem_t_min = -3.4028235E38;
+typedef float acc_t;
+typedef double full_t;
+
+#define ELEM_T_IS_FLOAT
+#define ELEM_T_EXP_BITS 8
+#define ELEM_T_SIG_BITS 24
+#define ACC_T_EXP_BITS 8
+#define ACC_T_SIG_BITS 24
+typedef uint32_t elem_t_bits;
+typedef uint32_t acc_t_bits;
 
 #define HAS_MVIN_SCALE
 typedef float scale_t;
 typedef uint32_t scale_t_bits;
 
-typedef int32_t scale_acc_t;
+#define HAS_MVIN_ACC_SCALE
+typedef float scale_acc_t;
 typedef uint32_t scale_acc_t_bits;
 
 typedef float acc_scale_t;
@@ -37,11 +46,8 @@ typedef uint32_t acc_scale_t_bits;
 
 #define ACC_SCALE_IDENTITY 1.0
 
-// Rounding right shift equation: https://riscv.github.io/documents/riscv-v-spec/#_vector_fixed_point_rounding_mode_register_vxrm
 #define ROUNDING_RIGHT_SHIFT(x, shift) \
-    ((shift) > 0 ? (((x) >> (shift)) + \
-        (((shift) == 0 ? 0 : (((x) >> ((shift)-1)) & 1)) & \
-             ((((shift) <= 1 ? 0 : ((x) & ((1 << ((shift)-1)) - 1))) != 0) | (((x) >> (shift)) & 1)))) : ((x) << (-(shift))))
+    ((x) / (1 << (shift)))
 
 #ifdef __cplusplus
 #define SAME_TYPE(x) decltype(x)
@@ -66,18 +72,20 @@ typedef uint32_t acc_scale_t_bits;
          ((((shift) <= 1 ? 0 : ((x) & ((1 << ((shift)-1)) - 1))) != 0) | (((x) >> (shift)) & 1)))) : ((x) << (-(shift))))
 
 #define ACC_SCALE(x, scale) \
-    ({float y = ROUND_NEAR_EVEN((x) * (scale)); y > INT8_MAX ? INT8_MAX : (y < INT8_MIN ? INT8_MIN : (acc_t)y);})
+    ((x) * (scale))
 
 #define MVIN_SCALE(x, scale) \
-    ({float y = ROUND_NEAR_EVEN((x) * (scale)); y > INT8_MAX ? INT8_MAX : (y < INT8_MIN ? INT8_MIN : (elem_t)y);})
+    ((x) * (scale))
 
-#define MVIN_SCALE_ACC(x, scale) (x)
+#define MVIN_SCALE_ACC(x, scale) \
+    ((x) * (scale))
 
 #define ACC_SCALE_T_IS_FLOAT
 #define ACC_SCALE_EXP_BITS 8
 #define ACC_SCALE_SIG_BITS 24
 
 #define ACC_READ_SMALL_WIDTH
+#define ACC_READ_FULL_WIDTH
 
 #define HAS_FIRST_LAYER_OPTIMIZATIONS
 


### PR DESCRIPTION
This allows data from the accumulator (or the scratchpad itself) to be moved to the scratchpad, instead of having to stage through L2/DRAM. Required for GPU